### PR TITLE
Fixed #60: 'Replace 'Places' with 'Resources''

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
         <li><a href="#programs">Programs</a></li>
         <li class="toggle"><a href="#main-menu">Contribute<span class="fas fa-chevron-down"></span></a>
             <ul>
-              <li><a href="/newcomers">Newcomers</a></li>
+              <li><a href="./newcomers.html">Newcomers</a></li>
               <li><a href="/open-source-workflow">Open Source Workflow</a></li>
               <li><a href="/member-levels">Member Levels</a></li>
             </ul>

--- a/newcomers.html
+++ b/newcomers.html
@@ -50,7 +50,7 @@
         <li><a href="/index.html#programs">Programs</a></li>
         <li class="toggle"><a href="#main-menu">Contribute<span class="fas fa-chevron-down"></span></a>
             <ul>
-              <li><a href="/newcomers">Newcomers</a></li>
+              <li><a href="./newcomers.html">Newcomers</a></li>
               <li><a href="/open-source-workflow">Open Source Workflow</a></li>
               <li><a href="/member-levels">Member Levels</a></li>
             </ul>
@@ -75,7 +75,7 @@
     <p>Each project has issues labeled "First Timers Only," try working on one of those for your first pull request.</p> 
     <p>Below there are tutorials and cheat sheets from Git to Glitch to Markdown. As well as information on how to help, even if you're not a developer.  If you need help reach out on the #questions Slack channel or in the channel for the specific project you have questions about (#portal for the portal repo, etc.)</p>
 
-<div class="subheader"><h3>Tutorials and Other Helpful Places</h3></div>
+<div class="subheader"><h3>Tutorials and Other Helpful Resources</h3></div>
 <ul class="newcomers">
     <li>Here’s a 15 minute tutorial from GitHub to learn <a href="https://try.github.io/levels/1/challenges/1" target="_blank">Git</a> or use this <a href="https://github.com/jlord/git-it-electron" target="_blank">awesome tutorial</a>.</li>
     <li>After you’ve got a basic understanding of Git, work through some <a href="https://guides.github.com/" target="_blank">Github Tutorials.</a></li>


### PR DESCRIPTION
### Description

- Replace 'Places' with 'Resources' for new comers.
- The href link to and from 'newcomers.html' was incorrectly referenced, changed it to ```./newcomers.html```.

Fixes #60 

### Type of Change:
- Code

### How Has This Been Tested?
Preview link of surge: http://sloppy-muscle.surge.sh/

### Checklist:
**Delete irrelevant options.**

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [X] My changes generate no new warnings 