### PR TITLE
Added 'IE=edge' value to content attribute

### DIFF
--- a/Outreachy/2017.html
+++ b/Outreachy/2017.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/RGSoC/2018.html
+++ b/RGSoC/2018.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/contactus.html
+++ b/contactus.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/gsoc/2009.html
+++ b/gsoc/2009.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/gsoc/2010.html
+++ b/gsoc/2010.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/gsoc/2011.html
+++ b/gsoc/2011.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/gsoc/2012.html
+++ b/gsoc/2012.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/gsoc/2013.html
+++ b/gsoc/2013.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/gsoc/2014.html
+++ b/gsoc/2014.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/gsoc/2015.html
+++ b/gsoc/2015.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/gsoc/2016.html
+++ b/gsoc/2016.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/gsoc/2017.html
+++ b/gsoc/2017.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/member-levels.html
+++ b/member-levels.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/newcomers.html
+++ b/newcomers.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/open-source-workflow.html
+++ b/open-source-workflow.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">

--- a/reporting-guidelines.html
+++ b/reporting-guidelines.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1, IE=edge">
     <title>Systers Open Source Projects by Systers</title>
 
     <link rel="stylesheet" href="/stylesheets/styles.css">


### PR DESCRIPTION
### Description
I have added the value 'IE-edge' to the http-equiv attribute of meta element,
so that it smoothly runs on IE as well.

Fixes #57 

### Type of Change:
- Code
- Quality Assurance  

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
Tested on IE. Now runs on it well.

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials  

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 