### PR TITLE
Consistency in the height of each table data for the various programs

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -319,6 +319,7 @@ table {
 }
 
 td {
+  height: 4rem;
   overflow: auto;
   padding: .5rem;
 }


### PR DESCRIPTION
### Description
Currently, for the various programs, the table having the details about the participants, mentors, etc does not have cells of consistent heights.

Fixes #108

### Type of Change:
- Code
- User Interface
  

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
I have tested this both on Chrome on my desktop as well as Chrome Dev Emulator.
Attached are the screenshots:
![screen shot 2018-03-19 at 6 29 54 pm](https://user-images.githubusercontent.com/22029744/37596885-9eea924e-2ba3-11e8-96e2-06d99a126e60.png)
![screen shot 2018-03-19 at 6 29 41 pm](https://user-images.githubusercontent.com/22029744/37596887-a089e4c4-2ba3-11e8-9e36-54fb4c9abdcf.png)

### Checklist:

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 