### PR TITLE
Fixed programs link in Member Levels > Mentors section

### DIFF
--- a/member-levels.html
+++ b/member-levels.html
@@ -144,7 +144,7 @@
         <p>These are ways to participate in addition to the levels listed above. Some are less focused on coding and GitHub contributions.</p>
 
         <div class="subheader"><h2>Mentor</h2></div>
-        <p>Mentors volunteer their time to assist contributors in the various <a href="http://localhost:8001/index.html/#programs">programs</a> Systers participates in.  People are more likely to be chosen as a mentor if they at least meet the Improver requirements.</p>
+        <p>Mentors volunteer their time to assist contributors in the various <a href="/index.html/#programs">programs</a> Systers participates in.  People are more likely to be chosen as a mentor if they at least meet the Improver requirements.</p>
         <h3>Benefits:</h3>
         <ul class="withBullets">
             <li>Name added to the Members Appreciation page and receive a Digital Certificate</li>

--- a/member-levels.html
+++ b/member-levels.html
@@ -144,7 +144,7 @@
         <p>These are ways to participate in addition to the levels listed above. Some are less focused on coding and GitHub contributions.</p>
 
         <div class="subheader"><h2>Mentor</h2></div>
-        <p>Mentors volunteer their time to assist contributors in the various <a href="/index.html/#programs">programs</a> Systers participates in.  People are more likely to be chosen as a mentor if they at least meet the Improver requirements.</p>
+        <p>Mentors volunteer their time to assist contributors in the various <a href="/index.html#programs">programs</a> Systers participates in.  People are more likely to be chosen as a mentor if they at least meet the Improver requirements.</p>
         <h3>Benefits:</h3>
         <ul class="withBullets">
             <li>Name added to the Members Appreciation page and receive a Digital Certificate</li>


### PR DESCRIPTION
### Description
I just removed the localhost:8001 part of the link to programs.
Before: http://localhost:8001/index.html/#programs
Now: /index.html#programs

Fixes #159

### Type of Change:
**Delete irrelevant options.**

- Code  

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
I went locally to the page Members Levels and clicked the link, which had the proper path. 
This led me to the appropriate page "/index.html/#programs".

### Checklist:
**Delete irrelevant options.**

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
  
**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been published in downstream modules
