### PR TITLE
1 CSS property is overridden

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -125,7 +125,6 @@ it wouldn't be clickable.
   width: 100%;
   height: 100%;
   z-index: 998;
-  background: #000;
   background: rgba(0,0,0,.85);
   cursor: default;
 }


### PR DESCRIPTION
### Description
Overridden "background" property from "main-menu:target + .backdrop" is removed
.main-menu:target + .backdrop{ background: rgba(0,0,0,.85); }

### Fixes [#144](https://github.com/systers/systers.github.io/issues/144)
Type of Change
   - Code

### Code/Quality Assurance Only

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Changes made successfully run on the heroku made web application .

### Checklist:

Delete irrelevant options.

- [x] PR follows the style guidelines of this project
- [x] I have performed a self-review of the code.

Code/Quality Assurance Only
- [x] The  changes generate no new warnings
