### PR TITLE
Fixed Systers open source mailing list link text

### DIFF
--- a/contactus.html
+++ b/contactus.html
@@ -74,10 +74,10 @@
     <div class="header"><h1>Contact Systers</h1></div>
         
     <ul>
-        <li class="horizontal"><a href="http://systers.io/slack-systers-opensource/" target="_blank">Slack</a></li>
+        <li class="horizontal"><a href="http://systers.io/slack-systers-opensource/" target="_blank">Systers Open Source Slack</a></li>
         <li class="horizontal"><a href="https://github.com/systers" target="_blank">GitHub</a></li>
         <li class="horizontal"><a href="https://twitter.com/systers_org" target="_blank">Twitter</a></li>
-        <li class="horizontal"><a href="http://systers.org/mailman/listinfo/systers-opensource" target="_blank">Systers Mailing List</a></li>
+        <li class="horizontal"><a href="http://systers.org/mailman/listinfo/systers-opensource" target="_blank">Systers Open Source Mailing List</a></li>
 
     </ul>
 


### PR DESCRIPTION
### Description
I just changed the text for the Systers Open Source mailing list and the Systers Open Source Slack link, on the [Contact Us](http://systers.io/contactus.html) page.

Fixes #167 

### Type of Change:

- Code
- Quality Assurance
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I ran the website locally as explained on README. 
Here's the updated screen:

![image](https://user-images.githubusercontent.com/11148726/38470874-3b43387c-3b61-11e8-8be2-8f8e27940cd1.png)

### Checklist:

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials

**Code/Quality Assurance Only**
- [ ] My changes generate no new warnings 
- [ ] New and existing unit tests pass locally with my changes
