### PR TITLE
Added missing SEO meta tags

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -24,6 +24,22 @@
   <meta property="og:url" content="http://www.systers.io" />
   <meta property="og:site_name" content="Systers" />
   <!-- OGP ends here -->
+
+  <!-- Twitter card -->
+  <meta name="twitter:card" content="website">
+  <meta name="twitter:site" content="Systers Open Source">
+  <meta name="twitter:title" content="Systers Open Source">
+  <meta name="twitter:description" content="Main GitHub web page for Systers at http://www.systers.io">
+  <meta name="twitter:creator" content="@systers_org">
+  <meta name="twitter:image" content="http://systers.io/images/systers-logo.png">
+  <!-- Twitter car ends here -->
+
+  <!-- Google plus -->
+  <meta itemprop="name" content="Systers Open Source">
+  <meta itemprop="description" content="Main GitHub web page for Systers at http://www.systers.io">
+  <meta itemprop="image" content="http://systers.io/images/systers-logo.png">
+  <!-- Google plus ends here -->
+  
  </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
### Description

`<meta >` tags for Twitter Card and Google+ was missing. Added both missing meta tags.

- Learn  about [Meta tags for Twitter card](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started)
- Learn about [Meta tags for Google+](https://www.blogsupporter.com/2016/05/add-social-meta-tags-for-twitter-google-plus.html)

### Type of Change:

- Code
  
### Checklist:

- [X] My PR follows the style guidelines of this project
- [X] I have performed a self-review of my own code or materials
- [X] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
